### PR TITLE
fix: use GH_RELEASE_PAT in pipeline

### DIFF
--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -50,7 +50,7 @@ jobs:
           tag_name: ${{ steps.get_tag.outputs.TAG }}
           files: obfs-exporter-linux-amd64.tar.gz
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_RELEASE_PAT }}
 
       # --- Docker Hub login & push (unchanged) ---
       - name: Log in to Docker Hub

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,7 +7,7 @@ permissions:
   contents: write
 
 jobs:
-  release:
+  semantic-release:
     runs-on: ubuntu-latest
     container:
       image: docker.io/plushguardian/semantic-release-for-ci:1.0.1
@@ -21,5 +21,5 @@ jobs:
 
       - name: Run semantic-release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_RELEASE_PAT }}
         run: npx semantic-release


### PR DESCRIPTION
https://github.com/PlushGuardian/obfuscation-server-exporter/issues/4